### PR TITLE
Fix version passing and updates to easy_install requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Questions, comments, and pull requests welcome; here, or richard.goodwin@rackspa
 
 
 ### Installation
+    Ubuntu:
+    apt-get install python-dev
+    apt-get install libffi-dev
 
     git clone git@github.com:rtgoodwin/superglance.git
     cd superglance

--- a/setup.py
+++ b/setup.py
@@ -15,16 +15,15 @@
 #   limitations under the License.
 #
 from setuptools import setup
-from superglance import superglance
 
 
 setup(
     name='superglance',
-    version=superglance.__version__,
+    version='0.7.5',
     author='Richard Goodwin (but mostly Major Hayden)',
     author_email='richard.goodwin@rackspace.com',
     description="glanceclient wrapper for multiple glance environments",
-    install_requires=['keyring'],
+    install_requires=['six>=1.4.1', 'keyring', 'simplejson', 'pycrypto', 'python-glanceclient'],
     packages=['superglance'],
     url='https://github.com/rtgoodwin/superglance',
     entry_points={

--- a/superglance/superglance.py
+++ b/superglance/superglance.py
@@ -179,7 +179,7 @@ class SuperGlance:
         self.glance_env = env
         assert self.is_valid_environment(), "Env %s not found in config." % env
         self.prep_keystone_creds()
-        return glanceclient.Client(self.keystone_creds.get('version', '1'),
+        return glanceclient.Client(self.keystone_creds.pop('version', '1'),
             self.image_url,
             token=ksclient.Client(**self.keystone_creds).auth_token
         )


### PR DESCRIPTION
This fixes an issue with passing glance_client via superglance config(ie. GLANCECLIENT_VERSION = 2) and updates easy_install to install dependencies.  Works as long as python-dev and libffi-dev packages are installed. So, Ubuntu install process would be:

`
apt-get install python-dev
apt-get install libffi-dev
python setup.py install
` 
